### PR TITLE
Use Azure DevOps UI Colors to match with the current theme

### DIFF
--- a/src/Components/RESTRequestButton/RESTRequestButton.scss
+++ b/src/Components/RESTRequestButton/RESTRequestButton.scss
@@ -13,9 +13,10 @@
     width: 100%;
     max-width: 100%;
     font-family: $fontFamilyMonospace;
-    background: rgba(244, 244, 244);
+    background: $neutral-alpha-30;
     overflow: hidden;
     overflow-x: auto;
+    color: $primary-text;
 }
 
 .resultbox:empty {


### PR DESCRIPTION
Hi,

First of all, thank you for this great extension. 
It gives me exactly what I need. 

However, there is one small thing that bothers me
When using the dark theme, the text of the response cannot be read. 
![Button_old](https://github.com/Zt-freak/DevOpsWorkItemRESTRequestButton/assets/22131101/f8025c28-ec2b-4e6e-ae67-996280174939)

This change adapts the result box to the currently selected theme. 

Dark:
![Button_Dark](https://github.com/Zt-freak/DevOpsWorkItemRESTRequestButton/assets/22131101/cd735843-ab39-4e70-b710-50e21b55f9af)

Light:
![Button_Light](https://github.com/Zt-freak/DevOpsWorkItemRESTRequestButton/assets/22131101/bc2fafd9-a7ff-461b-9961-14faa6db42a9)

