### PR TITLE
Switch back to Azure DevOps UI Colors

### DIFF
--- a/src/Components/RESTRequestButton/RESTRequestButton.scss
+++ b/src/Components/RESTRequestButton/RESTRequestButton.scss
@@ -13,21 +13,10 @@
     width: 100%;
     max-width: 100%;
     font-family: $fontFamilyMonospace;
-    background: rgba(121, 121, 121);
+    background: $neutral-alpha-30;
     overflow: hidden;
     overflow-x: auto;
-}
-
-@media (prefers-color-scheme: dark) {
-    .resultbox {
-        color: #FFF;
-    }
-}
-
-@media (prefers-color-scheme: light) {
-    .resultbox {
-        color: #000;
-    }
+    color: $primary-text;
 }
 
 .resultbox:empty {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,14 @@ module.exports = {
             },
             {
                 test: /\.s[ac]ss?$/,
-                use: ["style-loader", "css-loader", "azure-devops-ui/buildScripts/css-variables-loader", "sass-loader"]
+                use: ["style-loader", "css-loader", "azure-devops-ui/buildScripts/css-variables-loader", {
+                    loader: "sass-loader",
+                    options: {
+                        sassOptions: {
+                            outputStyle: 'expanded'
+                        }
+                    }
+                }]
             },
             {
                 test: /\.css?$/,
@@ -51,7 +58,7 @@ module.exports = {
     },
     plugins: [
         new CopyWebpackPlugin({
-           patterns: [ 
+           patterns: [
                { from: "**/*.html", context: "src/Components" }
            ]
         })


### PR DESCRIPTION
Hi, 

it took me some time to figure out, why the error you mentioned in #177 occurs. 
I found this PR in the Azure DevOps Extension Sample Repo: https://github.com/microsoft/azure-devops-extension-sample/pull/116

As described in the PR we have to expand the output style. 

I tried it with his code and it works! 😊

![image](https://github.com/Zt-freak/DevOpsWorkItemRESTRequestButton/assets/22131101/7e8bc69e-759b-4b9c-9ccb-c03906df550f)
